### PR TITLE
chore: Restrict `match` to `https://typst.app/project/*`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       userscript: {
         author: 'paran3xus',
         namespace: 'npm/vite-plugin-monkey',
-        match: ['https://typst.app/*'],
+        match: ['https://typst.app/project/*'],
         license: 'MPL 2.0',
         description: 'Format code using typstyle in typst.app'
       },


### PR DESCRIPTION
Could you change the `match` from `https://typst.app/*` to `https://typst.app/project/*`? This will exclude `https://typst.app/docs/`, etc.

**EDIT**: It won't work if the project is opened from https://typst.app (when logged in). I'll try something like `["^https://typst\.app/?", "https://typst.app/project/*"]` later.